### PR TITLE
add filter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ Aggregate all items in a single issue
 
 Limit size of issue content
 
+### `titleFilter`
+
+Don't create an issue if the title matches the specified regular expression ([go regular expression syntax](https://github.com/google/re2/wiki/Syntax))
+
+### `contentFilter`
+
+Don't create an issue if the content matches the specified regular expression ([go regular expression syntax](https://github.com/google/re2/wiki/Syntax))
+
 ## Outputs
 
 ### `issues`

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"text/template"
 	"time"
+	"regexp"
 
 	"github.com/google/go-github/v33/github"
 	"golang.org/x/oauth2"
@@ -30,6 +31,8 @@ const (
 	prefixInput    = "prefix"
 	aggregateInput = "aggragate"
 	dryRunInput    = "dry-run"
+	titleFilterInput    = "titleFilter"
+	contentFilterInput    = "contentFilter"
 )
 
 func main() {
@@ -113,6 +116,24 @@ func main() {
 		content := item.Content
 		if content == "" {
 			content = item.Description
+		}
+
+
+		filter := a.GetInput(titleFilterInput)
+		if filter !="" {
+			matched, _ := regexp.MatchString(filter, item.Title)
+			if matched {
+				a.Debugf("No issue created due to title filter")
+				continue
+			}
+		}
+		filter = a.GetInput(contentFilterInput)
+		if filter !="" {
+			matched, _ := regexp.MatchString(filter, content)
+			if matched {
+				a.Debugf("No issue created due to content filter")
+				continue
+			}
 		}
 
 		markdown, err := converter.ConvertString(content)


### PR DESCRIPTION
This allows filtering out the feed entries that you don't care about.

For example let's say I'd want to get Issues for new `Cygwin` releases. 
I'd setup `rss-issues-action` to create issues from `https://github.com/cygwin/cygwin/releases.atom`, 
but to only get issues for `Cygwin` releases I'd still need to filter out the `newlib` releases.